### PR TITLE
Fixed bugs in Metrics / InfluxDB config

### DIFF
--- a/conf/influxdb/influxdb.conf
+++ b/conf/influxdb/influxdb.conf
@@ -25,7 +25,7 @@ reporting-disabled = true
   batch-pending = 5
   batch-timeout = "1s"
   templates = [
-    "fluo.*.*.tx.*.*.* ..app.host.measurement.measurement.observer.field",
-    "fluo.*.*.*.*.* ..app.host.measurement.measurement.field",
-    "fluo.*.*.*.* ..app.host.measurement.measurement",
+    "fluo.*.*.tx.*.*.* .app.host.measurement.measurement.observer.field",
+    "fluo.*.*.*.*.* .app.host.measurement.measurement.field",
+    "fluo.*.*.*.* .app.host.measurement.measurement",
   ]


### PR DESCRIPTION
* Bug was causing metrics to be stored incorrectly
  in InfluxDB and not render in Grafana