### PR TITLE
Consider explicitly setting JAVA_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ environment :
 
  * [Ubuntu 16.04](/docs/ubuntu1604.md)
 
-If your system is setup correctly, the following command should print `JAVA_HOME` without asking for
-a password.
-
-```bash
-ssh localhost env | grep JAVA_HOME
-```
-
 ## Quickstart
 
 The following commands will get you up and running with an Accumulo instance if you

--- a/bin/impl/load-env.sh
+++ b/bin/impl/load-env.sh
@@ -96,6 +96,11 @@ if [[ ! -d "$INSTALL" ]]; then
   mkdir -p "$INSTALL"
 fi
 
+if [[ -z "$JAVA_HOME" || ! -d "$JAVA_HOME" ]]; then
+  echo "JAVA_HOME must be set in your shell to a valid directory.  Currently, JAVA_HOME=$JAVA_HOME"
+  exit 1
+fi
+
 : "${DATA_DIR:?"DATA_DIR is not set in uno.conf"}"
 : "${FLUO_VERSION:?"FLUO_VERSION is not set in uno.conf"}"
 : "${HADOOP_VERSION:?"HADOOP_VERSION is not set in uno.conf"}"

--- a/bin/impl/setup-hadoop.sh
+++ b/bin/impl/setup-hadoop.sh
@@ -44,6 +44,7 @@ $SED "s#YARN_LOGS#$YARN_LOG_DIR#g" "$hadoop_conf/yarn-site.xml"
 $SED "s#YARN_NM_MEM_MB#$YARN_NM_MEM_MB#g" "$hadoop_conf/yarn-site.xml"
 $SED "s#YARN_NM_CPU_VCORES#$YARN_NM_CPU_VCORES#g" "$hadoop_conf/yarn-site.xml"
 $SED "s#\#export HADOOP_LOG_DIR=[^ ]*#export HADOOP_LOG_DIR=$HADOOP_LOG_DIR#g" "$hadoop_conf/hadoop-env.sh"
+$SED "s#\${JAVA_HOME}#${JAVA_HOME}#g" "$hadoop_conf/hadoop-env.sh"
 $SED "s#YARN_LOG_DIR=[^ ]*#YARN_LOG_DIR=$YARN_LOG_DIR#g" "$hadoop_conf/yarn-env.sh"
 
 "$HADOOP_PREFIX"/bin/hdfs namenode -format


### PR DESCRIPTION
We should consider explicitly setting the JAVA_HOME variable in the setup-hadoop.sh script. On Ubuntu there appears to be some issues with the system reading the system JAVA_HOME variable. See https://stackoverflow.com/questions/21533725/hadoop-2-2-0-fails-running-start-dfs-sh-with-error-java-home-is-not-set-and-cou/38613613 for a discussion of the issue.

In my experiences, I have had to modify the script to get the 'uno start accumulo' command to successfully start hdfs properly on Ubuntu 16.04.